### PR TITLE
Datashield settings moved to a separate file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 6.2.0-1
 Author: Soumya Banerjee, Demetris Avraam, Xavier Escriba Montagut, Juan Gonzalez, Paul Burton and Tom R P Bishop <sb2333@cam.ac.uk>
 Maintainer: Soumya Banerjee, Demetris Avraam, Xavier Escriba Montagut, Juan Gonzalez, Paul Burton and Tom R P Bishop <sb2333@cam.ac.uk>
 License: GPL-3
-Depends: 
+Depends:
     R (>= 3.5.0)
 Imports:
     RANN,
@@ -15,24 +15,4 @@ Imports:
     dplyr,
     reshape2,
     dsBase
-AggregateMethods:
-    coxphSLMADS,
-    coxphSummaryDS,
-    cox.zphSLMADS,
-    summarySurvDS,
-    plotsurvfitDS
-AssignMethods:
-    coxphSLMAassignDS,
-    SurvDS,
-    survfitDS
-Options:
-    datashield.privacyLevel=5,
-    default.nfilter.glm=0.33,
-    default.nfilter.kNN=3,
-    default.nfilter.string=80,
-    default.nfilter.subset=3,
-    default.nfilter.stringShort=20,
-    default.nfilter.tab=3,
-    default.nfilter.noise=0.25,
-    default.nfilter.levels=0.33
 RoxygenNote: 7.1.1

--- a/inst/DATASHIELD
+++ b/inst/DATASHIELD
@@ -1,0 +1,20 @@
+AggregateMethods:
+    coxphSLMADS,
+    coxphSummaryDS,
+    cox.zphSLMADS,
+    summarySurvDS,
+    plotsurvfitDS
+AssignMethods:
+    coxphSLMAassignDS,
+    SurvDS,
+    survfitDS
+Options:
+    datashield.privacyLevel=5,
+    default.nfilter.glm=0.33,
+    default.nfilter.kNN=3,
+    default.nfilter.string=80,
+    default.nfilter.subset=3,
+    default.nfilter.stringShort=20,
+    default.nfilter.tab=3,
+    default.nfilter.noise=0.25,
+    default.nfilter.levels=0.33


### PR DESCRIPTION
Having the DS settings in the `DESCRIPTION` file is a legacy practice that is rejected by the official CRAN policy. It is recommended to have these in a separate file called `DATASHIELD` that will be installed at the root of the package (thus the "inst" directory) and that will be discovered by Opal.